### PR TITLE
[Feature] Adicionar tipo e setor dos ativos

### DIFF
--- a/@types/TradingViewQuoteResponse.ts
+++ b/@types/TradingViewQuoteResponse.ts
@@ -1,0 +1,13 @@
+export interface TradingViewQuoteResponse {
+  close?: number,
+  change?: number,
+  volume?: number,
+  market_cap_basic?: number,
+  description?: string, 
+  logoid: string,
+  type: string,
+  sector: string,
+  price_earnings_ttm: number,
+  earnings_per_share_basic_ttm: number
+}
+

--- a/pages/api/quote/list.tsx
+++ b/pages/api/quote/list.tsx
@@ -61,6 +61,7 @@ export default async (req: NextApiRequest, res: NextApiResponse) => {
       'market_cap_basic',
       'description',
       'logoid',
+      'type',
       'sector',
     ],
     sort: {
@@ -98,10 +99,12 @@ export default async (req: NextApiRequest, res: NextApiResponse) => {
     const availableStock = stock.s.replace('BMFBOVESPA:', '');
 
     const cleanName = cleanString(stock.d[4]);
+    const stockType = stock.d[6];
 
     const stockInformation = {
       stock: availableStock,
       name: cleanName,
+      type: stockType,
       close: stock.d[0],
       change: stock.d[1],
       volume: stock.d[2],
@@ -109,7 +112,7 @@ export default async (req: NextApiRequest, res: NextApiResponse) => {
       logo: stock.d[5]
         ? `https://s3-symbol-logo.tradingview.com/${stock.d[5]}--big.svg`
         : 'https://brapi.dev/favicon.svg',
-      sector: stock.d[6],
+      sector: stock.d[7],
     };
 
     return stockInformation;


### PR DESCRIPTION
## Objetivo do PR
Adicionar nas respostas de consulta de ativos o tipo do ativo e o setor dos mesmos.

## Exemplo de resposta atualizada

### /api/quote/MXRF11
![image](https://github.com/Alissonsleal/brapi/assets/10059323/b134f5a6-4b2d-46b4-882d-e96d41d176ab)

### /api/quote/list
![image](https://github.com/Alissonsleal/brapi/assets/10059323/5d7ecb0e-f8dc-43cc-b902-f9a9118c7782)


